### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An MCP server providing tools for interacting with the Penumbra blockchain. This server enables privacy-preserving interactions with Penumbra's core features including transaction queries, validator set information, DEX state, and governance proposals.
 
+<a href="https://glama.ai/mcp/servers/21fa1hhrxw"><img width="380" height="200" src="https://glama.ai/mcp/servers/21fa1hhrxw/badge" alt="Penumbra Server MCP server" /></a>
+
 ## Features
 
 ### Current Tools


### PR DESCRIPTION
This PR adds a badge for the [Penumbra MCP Server](https://glama.ai/mcp/servers/21fa1hhrxw) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/21fa1hhrxw"><img width="380" height="200" src="https://glama.ai/mcp/servers/21fa1hhrxw/badge" alt="Penumbra Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.